### PR TITLE
Add google tag manager (GTM) to theme

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,6 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{{ .Site.Title }} {{ with .Title }} | {{ . }}{{ end }}</title>
+    {{ if $.Site.Params.google_tag_manager }}
+    <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{ $.Site.Params.google_tag_manager }}');</script>
+    <!-- End Google Tag Manager -->
+    {{ end }}
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
@@ -15,6 +24,12 @@
     {{ end -}}
 </head>
 <body>
+  {{ if $.Site.Params.google_tag_manager }}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $.Site.Params.google_tag_manager }}"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  {{ end }}
 
     <!-- nav -->
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">


### PR DESCRIPTION
to use,  just add the following to config.toml

```
[params]
google_tag_manager = "<GTM code>"
```

If not defined, the generated page will not include the GTM snippets.